### PR TITLE
Method Renaming

### DIFF
--- a/pyblueiris/blueiris.py
+++ b/pyblueiris/blueiris.py
@@ -120,7 +120,7 @@ class BlueIris:
                 "Given invalid shortname for camera ({}). Using default value 'Index' instead.".format(camera))
             camera = "Index"
 
-        alertlist = await self.client.cmd("alertlist", {"camera": camera})
+        alertlist = await self.client.cmd("alertlist", {"camera": camera, "reset": "false"})
 
         for alert in alertlist:
             self._attributes["alertlist"][alert["camera"]].append(alert)

--- a/pyblueiris/blueiris.py
+++ b/pyblueiris/blueiris.py
@@ -144,3 +144,14 @@ class BlueIris:
             sysconfig = await self.client.cmd("sysconfig")
             self._attributes["sysconfig"] = sysconfig
 
+    async def update_all_information(self):
+        """Update all the information we can get from the Blue Iris server"""
+        if not self.am_logged_in:
+            await self.setup_session()
+
+        await self.update_status()
+        await self.update_camlist()
+        await self.update_cliplist()
+        await self.update_alertlist()
+        await self.update_log()
+        await self.update_sysconfig()

--- a/pyblueiris/blueiris.py
+++ b/pyblueiris/blueiris.py
@@ -33,7 +33,7 @@ class BlueIris:
     def attributes(self):
         return self._attributes
 
-    async def async_setup_session(self):
+    async def setup_session(self):
         """Initialize the session with the Blue Iris server"""
         session_info = await self.client.login(self.username, self.password)
         self._attributes["name"] = session_info.get('system name', UNKNOWN_STRING)
@@ -53,10 +53,10 @@ class BlueIris:
                     self._attributes["ptz_allowed"],
                     self._attributes["clips_allowed"], self._attributes["schedules"], self._attributes["version"]))
 
-    async def async_update_status(self):
+    async def update_status(self):
         """Updates Blue Iris status"""
         if not self.am_logged_in:
-            await self.async_setup_session()
+            await self.setup_session()
 
         status = await self.client.cmd("status")
         if self.debug:
@@ -67,23 +67,23 @@ class BlueIris:
         else:
             self._attributes["profile"] = self._attributes["profiles"][status["profile"]]
 
-    async def async_update_camlist(self):
+    async def update_camlist(self):
         """Updates known cameras on Blue Iris"""
         if not self.am_logged_in:
-            await self.async_setup_session()
+            await self.setup_session()
 
         camlist = await self.client.cmd("camlist")
         self._attributes["cameras"] = dict()
         for cam in camlist:
             self._attributes["cameras"][cam.get('optionValue')] = cam.get('optionDisplay')
 
-    async def async_update_cliplist(self, camera="Index"):
+    async def update_cliplist(self, camera="Index"):
         """Updates list of available clips. Provide a camera name to update an individual camera"""
         if not self.am_logged_in:
-            await self.async_setup_session()
+            await self.setup_session()
 
         if not self._attributes["cameras"]:
-            await self.async_update_camlist()
+            await self.update_camlist()
 
         if "cliplist" not in self._attributes:
             self._attributes["cliplist"] = dict()
@@ -101,13 +101,13 @@ class BlueIris:
         for clip in cliplist:
             self._attributes["cliplist"][clip["camera"]].append(clip)
 
-    async def async_update_alertlist(self, camera="Index"):
+    async def update_alertlist(self, camera="Index"):
         """Updates list of alerts. Provide a camera name to update an individual camera"""
         if not self.am_logged_in:
-            await self.async_setup_session()
+            await self.setup_session()
 
         if not self._attributes["cameras"]:
-            await self.async_update_camlist()
+            await self.update_camlist()
 
         if "alertlist" not in self._attributes:
             self._attributes["alertlist"] = dict()
@@ -125,18 +125,18 @@ class BlueIris:
         for alert in alertlist:
             self._attributes["alertlist"][alert["camera"]].append(alert)
 
-    async def async_update_log(self):
+    async def update_log(self):
         """Updates the log from Blue Iris"""
         if not self.am_logged_in:
-            await self.async_setup_session()
+            await self.setup_session()
 
         log = await self.client.cmd("log")
         self._attributes["log"] = log
 
-    async def async_update_sysconfig(self):
+    async def update_sysconfig(self):
         """Updates the system configuration status from Blue Iris"""
         if not self.am_logged_in:
-            await self.async_setup_session()
+            await self.setup_session()
 
         if not self._attributes["iam_admin"]:
             self.logger.error("The sysconfig command requires admin access. Current user is NOT admin")

--- a/pyblueiris/blueiris.py
+++ b/pyblueiris/blueiris.py
@@ -110,7 +110,7 @@ class BlueIris:
                     self._attributes["alertlist"][cam_shortname] = []
 
         alertlist = await self.client.cmd("alertlist", {"camera": camera, "reset": "false"})
-        if alertlist is None:
+        if alertlist is not dict:
             alertlist = dict()
         for alert in alertlist:
             self._attributes["alertlist"][alert["camera"]].append(alert)
@@ -161,7 +161,8 @@ class BlueIris:
     async def send_camera_reset(self, camera):
         """Send camconfig command to reset camera"""
         if await self.is_valid_camera(camera):
-            await self.client.cmd("camconfig", {"camera": camera, "reset": "true"})
+            resp = await self.client.cmd("camconfig", {"camera": camera, "reset": "true"})
+            return resp["result"]
 
     async def send_camera_enable(self, camera):
         """Send camconfig command to enable camera"""

--- a/pyblueiris/client.py
+++ b/pyblueiris/client.py
@@ -63,3 +63,5 @@ class BlueIrisClient:
             if self.debug:
                 self.logger.error("POST JSON: {}".format(args))
                 self.logger.error("RESPONSE: {}".format(rjson))
+            if rjson["result"]:
+                return rjson

--- a/test.py
+++ b/test.py
@@ -17,13 +17,13 @@ MY_LOGGER = logging.getLogger(__name__)
 async def tests():
     async with ClientSession(raise_for_status=True) as sess:
         blue = BI.BlueIris(sess, USER, PASS, PROTOCOL, HOST, debug=True, logger=MY_LOGGER)
-        await blue.async_setup_session()
-        await blue.async_update_status()
-        await blue.async_update_camlist()
-        await blue.async_update_cliplist()
-        await blue.async_update_alertlist()
-        await blue.async_update_log()
-        await blue.async_update_sysconfig()
+        await blue.setup_session()
+        await blue.update_status()
+        await blue.update_camlist()
+        await blue.update_cliplist()
+        await blue.update_alertlist()
+        await blue.update_log()
+        await blue.update_sysconfig()
 
         pprint.pprint(blue.attributes)
 

--- a/test.py
+++ b/test.py
@@ -20,7 +20,7 @@ async def tests():
         await blue.setup_session()
         await blue.update_all_information()
 
-        pprint.pprint(blue.attributes)
+        pprint.pprint(blue.attributes.get("camconfig"))
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -18,12 +18,7 @@ async def tests():
     async with ClientSession(raise_for_status=True) as sess:
         blue = BI.BlueIris(sess, USER, PASS, PROTOCOL, HOST, debug=True, logger=MY_LOGGER)
         await blue.setup_session()
-        await blue.update_status()
-        await blue.update_camlist()
-        await blue.update_cliplist()
-        await blue.update_alertlist()
-        await blue.update_log()
-        await blue.update_sysconfig()
+        await blue.update_all_information()
 
         pprint.pprint(blue.attributes)
 


### PR DESCRIPTION
Avoid prefixing all methods with `async_`... this is an entirely async library so it's redundant.